### PR TITLE
fix sorting and add missing item fields

### DIFF
--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -201,7 +201,7 @@ Source._on_stdout = function(_, data, _)
 							filterText = result.new_prefix;
 							insertText = result.new_prefix;
 							data = result;
-							sortText = (result.details or '') .. result.new_prefix;
+							sortText = result.new_prefix;
 						}
 						if result.detail ~= nil then
 							local percent = tonumber(string.sub(result.detail, 0, -2))
@@ -210,11 +210,19 @@ Source._on_stdout = function(_, data, _)
 								item['labelDetails'] = {
 									detail = result.detail
 								}
-								item['details'] = result.detail
+								item['sortText'] = string.format("%02d", 100 - percent) .. item['sortText']
+							else
+								item['detail'] = result.detail
 							end
 						end
 						if result.kind then
 							item['kind'] = result.kind
+						end
+						if result.documentation then
+							item['documentation'] = result.documentation
+						end
+						if result.deprecated then
+							item['deprecated'] = result.deprecated
 						end
 						table.insert(items, item)
 					end


### PR DESCRIPTION
Thanks for the great plugin! I created this pr because I noticed some faults when using, hope these will make sense :)

- Directly adding percent info added before `sort_text` will leads to inverse order of sorting, I think the value prepended should be the opposite of the percent value relative to 100
- TabNine may provides some fields of completion item with semantic completion enabled, so I just added the missing part