### PR TITLE
Correct setup sub-section header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tabnine:setup({
 })
 ```
 
-## `max_num_results`
+## `max_lines`
 
 How many lines of buffer context to pass to TabNine
 


### PR DESCRIPTION
I believe this section is actually referring to the `max_lines` option.