### PR TITLE
cmp-tabnine did not work on Windows for me.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,52 @@
 # cmp-tabnine
+
 TabNine source for [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 
 # Install
 
 Using plug:
-   ```viml
-   Plug 'tzachar/cmp-tabnine', { 'do': './install.sh' }
-   ```
+
+```viml
+Plug 'tzachar/cmp-tabnine', { 'do': './install.sh' }
+```
 
 Using plug on windows:
 
-	Plug 'tzachar/cmp-tabnine', { 'do': 'powershell ./install.ps1'}
+```viml
+Plug 'tzachar/cmp-tabnine', { 'do': 'powershell ./install.ps1'}
+```
 
 Using [Packer](https://github.com/wbthomason/packer.nvim/):
-   ```viml
+
+```lua
 return require("packer").startup(
 	function(use)
 		use "hrsh7th/nvim-cmp" --completion
 		use {'tzachar/cmp-tabnine', run='./install.sh', requires = 'hrsh7th/nvim-cmp'}
 	end
 )
-   ```
+```
+
 Using [Packer](https://github.com/wbthomason/packer.nvim/) on windows:
-   ```viml
+
+```lua
 return require("packer").startup(
 	function(use)
 		use "hrsh7th/nvim-cmp" --completion
 		use {'tzachar/cmp-tabnine', run='powershell ./install.ps1', requires = 'hrsh7th/nvim-cmp'}
 	end
 )
-   ```
-
+```
 
 And later, enable the plugin:
 
-   ```lua
+```lua
 require'cmp'.setup {
 	sources = {
 		{ name = 'cmp_tabnine' },
 	},
 }
-   ```
+```
 
 # Setup
 
@@ -71,7 +77,6 @@ How many results to return
 
 Sort results by returned priority
 
-
 ## `run_on_every_keystroke`
 
 Generate new completion items on every keystroke. For more info, check out [#18](https://github.com/tzachar/cmp-tabnine//issues/18)
@@ -84,16 +89,18 @@ snippet. Any string is accepted.
 For this to work properly, you need to setup snippet support for `nvim-cmp`.
 
 ## `ignored_file_types` `(table: <string:bool>)`
+
 Which file types to ignore. For example:
+
 ```
 ignored_file_types = {
 	html = true;
 }
 ```
+
 will make `cmp-tabnine` not offer completions when `vim.bo.filetype` is `html`.
 
-
-# Pretty Printing Menu Items 
+# Pretty Printing Menu Items
 
 You can use the following to pretty print the completion menu (requires
 [lspkind](https://github.com/onsails/lspkind-nvim) and patched fonts

--- a/install.ps1
+++ b/install.ps1
@@ -12,13 +12,11 @@ $path = "$version/$platform"
 
 iwr "https://update.tabnine.com/bundles/$path/TabNine.zip" -OutFile TabNine.zip
 
-if(!(Test-Path ./binaries)){
-	mkdir binaries
-}
+$tabnine_path = "$env:LOCALAPPDATA/nvim-data/binaries/$path"
 
 if(!(Test-Path "./binaries/$path")){
-	mkdir -p "binaries/$path"
+	mkdir -p $tabnine_path
 }
 
-expand-archive Tabnine.zip -destinationpath "./binaries/$path" -force
+expand-archive Tabnine.zip -destinationpath $tabnine_path -force
 Remove-Item -Recurse "./TabNine.zip"

--- a/install.ps1
+++ b/install.ps1
@@ -17,7 +17,7 @@ if(!(Test-Path ./binaries)){
 }
 
 if(!(Test-Path "./binaries/$path")){
-	mkdir "binaries/$path"
+	mkdir -p "binaries/$path"
 }
 
 expand-archive Tabnine.zip -destinationpath "./binaries/$path" -force

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -54,7 +54,13 @@ local function get_parent_dir(path)
 end
 
 -- do this once on init, otherwise on restart this dows not work
-local binaries_folder = get_parent_dir(get_parent_dir(script_path())) .. 'binaries'
+local binaries_folder
+
+if is_win() then
+    binaries_folder = fn.stdpath('data')..'\\binaries'
+else
+    binaries_folder = get_parent_dir(get_parent_dir(script_path())) .. 'binaries'
+end
 
 -- locate the binary here, as expand is relative to the calling script name
 local function binary()

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -17,8 +17,12 @@ local function json_decode(data)
 	end
 end
 
+local function is_win()
+  return fn.has('win64') == 1 or fn.has('win32') == 1
+end
+
 local function get_path_separator()
-    if ((fn.has('win64') == 1) or (fn.has('win32') == 1)) then return '\\' end
+    if is_win() then return '\\' end
     return '/'
 end
 
@@ -66,7 +70,10 @@ local function binary()
 	table.sort(versions, function (a, b) return a.version < b.version end)
 	local latest = versions[#versions]
 	if not latest then
-		vim.notify('cmp-tabnine: Cannot find installed TabNine. Please run install.sh')
+		vim.notify(string.format(
+		    'cmp-tabnine: Cannot find installed TabNine. Please run install.%s',
+		    (is_win() and 'ps1' or 'sh')
+		))
 		return
 	end
 
@@ -103,11 +110,9 @@ function Source.new()
 	return self
 end
 
-
 Source.is_available = function()
 	return (Source.job ~= 0)
 end
-
 
 Source.get_debug_name = function()
 	return 'TabNine'


### PR DESCRIPTION
Windows support was recently added #21 but I noticed that it wasn't working on my Windows machine. Whenever I ran nvim, I always got the error telling me to run `install.sh` even though I had already done so.<br/>
So I wanted to check where TabNine was downloaded on my machine: 

```ps1
$version = iwr https://update.tabnine.com/bundles/version
$version = $version.content

if([environment]::Is64bitOperatingSystem){
	$platform = 'x86_64-pc-windows-gnu'
}
else{
	$platform = 'i686-pc-windows-gnu'
}

$path = "$version/$platform"

iwr "https://update.tabnine.com/bundles/$path/TabNine.zip" -OutFile TabNine.zip

if(!(Test-Path ./binaries)){
	mkdir binaries
}

if(!(Test-Path "./binaries/$path")){
	mkdir "binaries/$path"
}

expand-archive Tabnine.zip -destinationpath "./binaries/$path" -force
Remove-Item -Recurse "./TabNine.zip"
```
So here, a `binaries/4.0.23/x86_64-pc-windows-gnu/...` folder is created next to an `install.sh` file<br/>
But for I then went to see where `source.lua` was looking for my TabNine installations:
```lua
local binaries_folder = get_parent_dir(get_parent_dir(script_path())) .. 'binaries'
print(binaries_folder)
--[[ output :
    C:\Users\Cyprien\AppData\Local\nvim-data\site\pack\packer\binaries
]]
````
So in my case, the binaries folder is not downloaded to the same place where it is searched.<br/>
I'm not a big fan of my modifications but I only propose a solution to make the plugin work for other users in my case. 
Good day to all ! (: