### PR TITLE
Fix #24: Correctly locate binaries folder on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Using plug:
    ```
 
 Using plug on windows:
-	```viml
-	Plug 'tzachar/cmp-tabnine', { 'do': 'powershell ./install.ps1'}
-	```
+   ```viml
+   Plug 'tzachar/cmp-tabnine', { 'do': 'powershell ./install.ps1' }
+   ```
 
 Using [Packer](https://github.com/wbthomason/packer.nvim/):
    ```lua

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Using plug:
    ```
 
 Using plug on windows:
-
+	```viml
 	Plug 'tzachar/cmp-tabnine', { 'do': 'powershell ./install.ps1'}
+	```
 
 Using [Packer](https://github.com/wbthomason/packer.nvim/):
-   ```viml
+   ```lua
 return require("packer").startup(
 	function(use)
 		use "hrsh7th/nvim-cmp" --completion
@@ -22,7 +23,7 @@ return require("packer").startup(
 )
    ```
 Using [Packer](https://github.com/wbthomason/packer.nvim/) on windows:
-   ```viml
+   ```lua
 return require("packer").startup(
 	function(use)
 		use "hrsh7th/nvim-cmp" --completion
@@ -85,7 +86,7 @@ For this to work properly, you need to setup snippet support for `nvim-cmp`.
 
 ## `ignored_file_types` `(table: <string:bool>)`
 Which file types to ignore. For example:
-```
+```lua
 ignored_file_types = {
 	html = true;
 }

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -17,8 +17,12 @@ local function json_decode(data)
 	end
 end
 
+local function is_win()
+  return package.config:sub(1,1) == "\\"
+end
+
 local function get_path_separator()
-    if ((fn.has('win64') == 1) or (fn.has('win32') == 1)) then return '\\' end
+    if is_win() then return '\\' end
     return '/'
 end
 
@@ -36,8 +40,11 @@ local function build_snippet(prefix, placeholder, suffix, add_final_tabstop)
 end
 
 local function script_path()
-   local str = debug.getinfo(2, "S").source:sub(2)
-   return str:match("(.*" .. get_path_separator() .. ")")
+    local str = debug.getinfo(2, "S").source:sub(2)
+    if is_win() then
+      str = str:gsub('/', '\\')
+    end
+    return str:match("(.*" .. get_path_separator() .. ")")
 end
 
 local function get_parent_dir(path)
@@ -66,7 +73,7 @@ local function binary()
 	table.sort(versions, function (a, b) return a.version < b.version end)
 	local latest = versions[#versions]
 	if not latest then
-		vim.notify('cmp-tabnine: Cannot find installed TabNine. Please run install.sh')
+		vim.notify(string.format('cmp-tabnine: Cannot find installed TabNine. Please run install.%s', (is_win() and 'ps1' or 'sh')))
 		return
 	end
 


### PR DESCRIPTION
the `is_win()` function is on the neovim repo [here](https://github.com/neovim/neovim/blob/master/test/helpers.lua#L262-L264)