### PR TITLE
fix potential unmatch of ctx and response

### DIFF
--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -212,16 +212,14 @@ Source._on_stdout = function(_, data, _)
 		if jd ~= nil and jd ~= '' then
 			local response = json_decode(jd)
 			-- dump(response)
-			if response == nil then
+			local id = (response or {}).correlation_id
+			if Source.pending[id] == nil then
 				-- the _on_exit callback should restart the server
 				-- fn.jobstop(Source.job)
-				dump('TabNine: json decode error: ', jd)
-			else
-				local id = response.correlation_id
-				if not Source.pending[id] then
-					return
+				if response == nil then
+					dump('TabNine: json decode error: ', jd)
 				end
-
+			else
 				local ctx = Source.pending[id].ctx
 				local callback = Source.pending[id].callback
 				Source.pending[id] = nil


### PR DESCRIPTION
In the current implementation we memorize the context provided cmp as a queue and assign it to the corresponding response. There are two main problems here:

- The ctx in the front of queue is stale and should not be handled, otherwise the position of insert text will be wrong. That means we only need to memorize one fresh ctx and record a queued number instead to skip the invalid response.
- Sometimes tabnine may fails to respond to the frequently sent requests and leads to unmatch of ctx list and response. We don't provide a method to avoid and recover from it previously, in this PR I add an event listener to cmp to reset the state on confirm done. There is also an addition to the document to present an alternative approach.