### PR TITLE
fix replace range in textEdit is ignored by cmp

### DIFF
--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -286,16 +286,19 @@ Source._on_stdout = function(_, data, _)
               old_suffix = string.sub(old_suffix, 1, -2)
             end
 
+            local range = {
+              start = { line = cursor.line, character = cursor.col - #old_prefix - 1 },
+              ['end'] = { line = cursor.line, character = cursor.col + #old_suffix - 1 },
+            }
+
             local item = {
               label = newText,
               filterText = newText,
               data = result,
               textEdit = {
-                range = {
-                  start = { line = cursor.line, character = cursor.col - #old_prefix - 1 },
-                  ['end'] = { line = cursor.line, character = cursor.col + #old_suffix - 1 },
-                },
                 newText = newText,
+                insert = range, -- May be better to exclude the trailing part of old_suffix since it's 'replaced'?
+                replace = range,
               },
               sortText = newText,
               dup = 0,


### PR DESCRIPTION
This bug is introduced since https://github.com/hrsh7th/nvim-cmp/commit/440897ef585ccef29e1edb927ea4b5afaf2fe304, where the range field in `textEdit` is no longer respected in replace mode.