### PR TITLE
lua/cmp_tabnine/config.lua Resolve `pairs` error at line 18.

### DIFF
--- a/lua/cmp_tabnine/config.lua
+++ b/lua/cmp_tabnine/config.lua
@@ -15,7 +15,7 @@ local conf_defaults = {
 }
 
 function M:setup(params)
-  for k, v in pairs(params) do
+  for k, v in pairs(params or {}) do
     conf_defaults[k] = v
   end
 end


### PR DESCRIPTION
I get the following error when installing cmp-tabnine.
This is a very small problem. The `pairs` may receive nil.
Therefore, if nil is passed, an empty object must be explicitly passed instead of nil.
If you accept my fix, the error will be resolved.
Thank you.

```
Error detected while processing /root/vivim/assets/nvim/init.lua:
E5113: Error while calling lua chunk: ...pack/packer/start/cmp-tabnine/lua/cmp_tabnine/config.lua:18: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
        [C]: in function 'pairs'
        ...pack/packer/start/cmp-tabnine/lua/cmp_tabnine/config.lua:18: in function 'setup'
        /root/.config/nvim/lua/plugin.lua:105: in main chunk
        [C]: in function 'require'
        /root/vivim/assets/nvim/init.lua:48: in main chunk

```