### PR TITLE
use arch instead of uname on macos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,10 @@ version=${version:-$(curl -sS https://update.tabnine.com/bundles/version)}
 
 case $(uname -s) in
 "Darwin")
-    if [ "$(uname -m)" == "arm64" ]; then
+    if [ "$(arch)" == "arm64" ]; then
         platform="aarch64-apple-darwin"
     else
-        platform="$(uname -m)-apple-darwin"
+        platform="$(arch)-apple-darwin"
     fi
     ;;
 "Linux")

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -113,14 +113,15 @@ local function binary()
   elseif fn.has('win32') == 1 then
     platform = 'i686-pc-windows-gnu'
   else
-    local arch, _ = string.gsub(fn.system({'uname',  '-m'}), '\n$', '')
     if fn.has('mac') == 1 then
+      local arch, _ = string.gsub(fn.system({'arch'}), '\n$', '')
       if arch == 'arm64' then
         platform = 'aarch64-apple-darwin'
       else
         platform = 'x86_64-apple-darwin'
       end
     elseif fn.has('unix') == 1 then
+      local arch, _ = string.gsub(fn.system({'uname',  '-m'}), '\n$', '')
       platform = arch .. '-unknown-linux-musl'
     end
   end


### PR DESCRIPTION
this is an admittedly roundabout way of solving an issue i encountered

when in a nix shell, uname can be provided by gnu-coreutils. in mildly older versions of gnu-coreutils, uname had a bug that identified m1 macs as having an x86 architecture. this solves that by using `arch` provided by macos insted of uname