### PR TITLE
Support custom TabNine binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ tabnine:setup({
 		-- uncomment to ignore in lua:
 		-- lua = true
 	},
-	show_prediction_strength = false
+	show_prediction_strength = false,
+        binary = { -- default is to use binary managed by plugin
+		-- uncomment to use cusom binary
+		-- path = "/my/custom/TabNine",
+		-- version = "4.4.265"
+        },
 })
 ```
 
@@ -134,6 +139,19 @@ will make `cmp-tabnine` not offer completions when `vim.bo.filetype` is `html`.
 When `show_prediction_strength` is true, `cmp-tabnine` will display
 the prediction strength as a percentage by assigning `entry.completion_item.data.detail`.
 This was previously the default behavior.
+
+## `binary` `(table: <string:string>)`
+
+A custom path/version for the TabNine binary. For example:
+
+```lua
+binary = {
+	path = "/my/custom/TabNine",
+	version = "4.4.265",
+}
+```
+
+will make `cmp-tabnine` use a manually installed binary.
 
 # Pretty Printing Menu Items
 

--- a/lua/cmp_tabnine/config.lua
+++ b/lua/cmp_tabnine/config.lua
@@ -12,6 +12,11 @@ local conf_defaults = {
     -- uncomment to ignore in lua:
     -- lua = true
   },
+  binary = { -- default is to use binary managed by plugin
+    -- uncomment to use cusom binary
+    -- path = "/my/custom/TabNine",
+    -- version = "4.4.265"
+  },
 }
 
 function M:setup(params)

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -88,6 +88,11 @@ end
 
 -- locate the binary here, as expand is relative to the calling script name
 local function binary()
+  local b = conf:get('binary')
+  if b and b.path and b.version then
+    return b.path, b.version
+  end
+
   local versions_folders = fn.globpath(binaries_folder, '*', false, true)
   local versions = {}
   for _, path in ipairs(versions_folders) do


### PR DESCRIPTION
Due to the usage of Nix for my plugin management (which enforces read-only fs access), I couldn't run `install.sh`. This new option allows me to install the actual [TabNine Nix package](https://search.nixos.org/packages?channel=unstable&type=packages&query=tabnine) and point `cmp-tabnine` to it.