### PR TITLE
Add kind highlight group

### DIFF
--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -366,6 +366,7 @@ function Source.on_stdout(self, data)
               dup = 0,
               cmp = {
                 kind_text = 'TabNine',
+                kind_hl_group = "CmpItemKindTabNine",
               },
             }
             -- This is a hack fix for cmp not displaying items of TabNine::config_dir, version, etc. because their


### PR DESCRIPTION
Add a TabNine cmp source with a builtin highlight group CmpItemKindTabNine, so users can add their own highlight, for example:

`vim.api.nvim_set_hl(0, "CmpItemKindTabNine", {fg ="#6CC644"})`