### PR TITLE
Eliminate items with a percentage less than min_percent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ tabnine:setup({
 		-- uncomment to ignore in lua:
 		-- lua = true
 	},
-	show_prediction_strength = false
+	show_prediction_strength = false,
+  min_percent = 0
 })
 ```
 
@@ -128,6 +129,10 @@ ignored_file_types = {
 }
 ```
 will make `cmp-tabnine` not offer completions when `vim.bo.filetype` is `html`.
+
+## `min_percent`
+
+Eliminate items with a percentage less than `min_percent`.
 
 # Pretty Printing Menu Items
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ tabnine:setup({
 		-- lua = true
 	},
 	show_prediction_strength = false,
-  min_percent = 0
+	min_percent = 0
 })
 ```
 

--- a/doc/cmp-tabnine.txt
+++ b/doc/cmp-tabnine.txt
@@ -153,6 +153,10 @@ Which file types to ignore. For example:
 
 will make `cmp-tabnine` not offer completions when `vim.bo.filetype` is `html`.
 
+MIN_PERCENT                                                  *cmp-tabnine-min_percent*
+
+Eliminate items with a percentage less than `min_percent`.
+
 
 ==============================================================================
 4. Pretty Printing Menu Items         *cmp-tabnine-pretty-printing-menu-items*

--- a/lua/cmp_tabnine/config.lua
+++ b/lua/cmp_tabnine/config.lua
@@ -5,6 +5,7 @@ local conf_defaults = {
   max_num_results = 20,
   sort = true,
   priority = 5000,
+  min_percent = 0,
   run_on_every_keystroke = true,
   snippet_placeholder = '..',
   ignored_file_types = { -- default is not to ignore

--- a/lua/cmp_tabnine/source.lua
+++ b/lua/cmp_tabnine/source.lua
@@ -388,6 +388,9 @@ function Source.on_stdout(self, data)
             if result.completion_metadata ~= nil then
               local percent = tonumber(string.sub(result.completion_metadata.detail, 0, -2))
               if percent ~= nil then
+                if percent <= conf:get('min_percent') then
+                  goto continue
+                end
                 item['priority'] = base_priority + percent * 0.001
                 item['sortText'] = string.format('%02d', 100 - percent) .. item['sortText']
               end
@@ -417,6 +420,7 @@ function Source.on_stdout(self, data)
             end
             table.insert(items, item)
           end
+          ::continue::
         else
           dump('no results:', jd)
         end


### PR DESCRIPTION
In Tabnine, the percentage represents the accuracy level. For me, I always expect the returned suggestions from Tabnine to have an accuracy level higher than 30%. Therefore, in this pull request, I have introduced the "min_percent" parameter, which will filter out suggestions with an accuracy level lower than min_percent and keep the rest